### PR TITLE
fix: value error from progress bar when content size undefined

### DIFF
--- a/dataloader.py
+++ b/dataloader.py
@@ -18,14 +18,19 @@ import yaml
 class ProgressBar():
     def __init__(self):
         self.pbar = None
+        self.no_content_length = False
 
     def __call__(self, block_num, block_size, total_size):
+        if total_size == -1:
+            self.no_content_length = True
+
         if not self.pbar:
-            self.pbar = progressbar.ProgressBar(maxval=total_size)
+            if self.no_content_length:
+                self.pbar = progressbar.ProgressBar(maxval=progressbar.UnknownLength if self.no_content_length else total_size)
             self.pbar.start()
 
         downloaded = block_num * block_size
-        if downloaded < total_size:
+        if downloaded < total_size or self.no_content_length:
             self.pbar.update(downloaded)
         else:
             self.pbar.finish()


### PR DESCRIPTION
The pull request addressed an issue when the `total_size` parameter in the `__call__` method of `ProgressBar()` is `-1`, indicating an unknown file size. This scenario commonly occurs when the server does not provide the content length header.

Previously, this situation led to a `ValueError` due to the negative `maxval`.
```
Traceback (most recent call last):
  File "/home/noishi/PycharmProjects/dl_har_public/dl_har_dataloader/preprocessing.py", line 237, in <module>
    preprocess_dataset(loader, args)
  File "/home/noishi/PycharmProjects/dl_har_public/dl_har_dataloader/preprocessing.py", line 152, in preprocess_dataset
    zf = dataset.open_zip()
  File "/home/noishi/PycharmProjects/dl_har_public/dl_har_dataloader/dataloader.py", line 112, in open_zip
    path = self.check_data()
  File "/home/noishi/PycharmProjects/dl_har_public/dl_har_dataloader/dataloader.py", line 138, in check_data
    self.get_data_from_url(paths)
  File "/home/noishi/PycharmProjects/dl_har_public/dl_har_dataloader/dataloader.py", line 160, in get_data_from_url
    urllib.request.urlretrieve(origin, path, ProgressBar())
  File "/home/noishi/.pyenv/versions/anaconda3-2023.03/envs/WIMUSim/lib/python3.10/urllib/request.py", line 267, in urlretrieve
    reporthook(blocknum, bs, size)
  File "/home/noishi/PycharmProjects/dl_har_public/dl_har_dataloader/dataloader.py", line 25, in __call__
    self.pbar.start()
  File "/home/noishi/.pyenv/versions/anaconda3-2023.03/envs/WIMUSim/lib/python3.10/site-packages/progressbar/progressbar.py", line 286, in start
    if self.maxval < 0: raise ValueError('Value out of range')
ValueError: Value out of range
```


To resolve this, I have made the following changes:

1. **Handling Unknown Total Size**:
   - Modified the ProgressBar code to accommodate unknown total sizes. Now, when `total_size` is `-1`, the `max_value` parameter for the progress bar is set to `progressbar.UnknownLength`. This modification allows the progress bar to function correctly, even when the total file size is not predetermined.

2. **Upgrade to progressbar2**:
   - Replaced the `progressbar` library with `progressbar2`. This library is a fork of the original `progressbar` and benefits from ongoing maintenance and additional features. The switch ensures better compatibility with future Python versions and improvements in functionality.

These updates aim to enhance the robustness and maintainability of our file download process. Please review the changes for integration into the main codebase.